### PR TITLE
fix: remove --disk-driver-version help entries to fix azdev linter

### DIFF
--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -421,9 +421,6 @@ helps['aks create'] = f"""
         - name: --disable-disk-driver
           type: bool
           short-summary: Disable AzureDisk CSI Driver.
-        - name: --disk-driver-version
-          type: string
-          short-summary: Specify AzureDisk CSI Driver version.
         - name: --disable-file-driver
           type: bool
           short-summary: Disable AzureFile CSI Driver.
@@ -1131,9 +1128,6 @@ helps['aks update'] = """
           long-summary: |
               Network dataplane used in the Kubernetes cluster.
               Specify "azure" to use the Azure dataplane (default) or "cilium" to enable Cilium dataplane.
-        - name: --disk-driver-version
-          type: string
-          short-summary: Specify AzureDisk CSI Driver version.
         - name: --disable-disk-driver
           type: bool
           short-summary: Disable AzureDisk CSI Driver.


### PR DESCRIPTION
Fix the `azdev-linter` CI failure in PR Azure/azure-cli-extensions#9856.

**Root cause:** `--disk-driver-version` parameter was removed from `_params.py`, `custom.py`, and `managed_cluster_decorator.py`, but the corresponding help entries in `_help.py` were not cleaned up.

**Linter error:**
```
FAIL - HIGH severity: unrecognized_help_parameter_rule
  Help-Entry: aks create - The following parameter help names are invalid: --disk-driver-version
  Help-Entry: aks update - The following parameter help names are invalid: --disk-driver-version
```

**Fix:** Remove the two `--disk-driver-version` help entry blocks from `_help.py` (aks create ~line 424 and aks update ~line 1134).